### PR TITLE
use go-version-file in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version-file: go.mod
           cache: true
 
       - name: Install Trivy


### PR DESCRIPTION
Replace hardcoded `go-version` with `go-version-file: go.mod` in CI workflow, so the Go version is managed in one place.